### PR TITLE
Allows for fog command without a physical stagekit

### DIFF
--- a/include/ports.h
+++ b/include/ports.h
@@ -45,6 +45,7 @@
 #define PORT_SONG_ID_EVALUATE 0x827aa7d4        // branch to DataNode::Evaluate in SongMetadata::__ct
 #define PORT_LOADOBJS_BCTRL 0x827562e4          // bctrl to Object::PreLoad insie of DirLoader::LoadObjs
 #define PORT_SONGMGR_ISDEMO_CHECK 0x82575f9c    // "bne" after IsUGC check inside SongMgr::IsDemo
+#define PORT_STAGEKIT_EXISTS 0x8228d03c         // StageKit check. nop over to allow for fog command without a physical StageKit connected.
 // function patch addresses
 #define PORT_SETDISKERROR 0x82516320                 // PlatformMgr::SetDiskError
 #define PORT_APP_RUN 0x82272e90                      // App::Run

--- a/source/rb3enhanced.c
+++ b/source/rb3enhanced.c
@@ -154,6 +154,9 @@ void ApplyPatches()
 #elif RB3E_XBOX
     if (RB3E_IsEmulator())
         POKE_32(PORT_SONGMGR_ISDEMO_CHECK, NOP);
+      
+    // skips check for stagekit to allow for fog commands to be issued without a stagekit plugged in
+    POKE_32(PORT_STAGEKIT_EXISTS, NOP);
 #endif
     RB3E_MSG("Patches applied!", NULL);
 }


### PR DESCRIPTION
Without this patch the light events are only sent without fog.