### PR TITLE
SK Led fix on score overview exit

### DIFF
--- a/include/rb3enhanced.h
+++ b/include/rb3enhanced.h
@@ -33,3 +33,8 @@ extern int RB3E_LoadedSongCount;
 
 // Emulator detection
 int RB3E_IsEmulator();
+
+// StageKit set state, needed for fixing LED bug.
+#ifdef RB3E_XBOX
+  void StagekitSetStateHook(int state1, int state2);
+#endif

--- a/source/GameHooks.c
+++ b/source/GameHooks.c
@@ -68,5 +68,12 @@ void *GameDestructHook(void *theGame, int r4)
 {
     char in_game = 0x00;
     RB3E_SendEvent(RB3E_EVENT_STATE, &in_game, sizeof(in_game));
+    
+#ifdef RB3E_XBOX
+    // When not in-game, turn off the stage-kit lights.
+    // Fixes the RB3 bug(?) that leaves 2 red leds on when exiting the score view screen.
+    StagekitSetStateHook(0x00, 0xFF);    
+#endif
+
     return GameDestruct(theGame, r4);
 }


### PR DESCRIPTION
Fixes the RB3 (bug?) where 2 red leds stay on after exiting the score screen.  This fix turns them off when exiting the score screen.