### PR TITLE
Extend strncpy(config.GoCentralAddress) to full field length

### DIFF
--- a/source/config.c
+++ b/source/config.c
@@ -80,7 +80,7 @@ static int INIHandler(void *user, const char *section, const char *name, const c
         if (strcmp(name, "EnableGoCentral") == 0)
             config.EnableGoCentral = RB3E_CONFIG_BOOL(value);
         if (strcmp(name, "GoCentralAddress") == 0)
-            strncpy(config.GoCentralAddress, value, RB3E_MAX_CONFIG_LEN);
+            strncpy(config.GoCentralAddress, value, RB3E_MAX_DOMAIN);
     }
     if (strcmp(section, "HTTP") == 0)
     {


### PR DESCRIPTION
config.GoCentralAddress is defined in the ini spec in config.h as being of up to RB3E_MAX_DOMAIN chars, but the strncpy routine for that item was only copying RB3E_MAX_CONFIG_LEN; this was 30 chars. The announced Xbox URI (`gocentral-xbox.rbenhanced.rocks`) had precisely 31 characters. This caused all DNS lookups for this address to fail, and no connection to be made to the GoCentral server.