### PR TITLE
DX Song Search DTAFunction

### DIFF
--- a/include/GlobalSymbols.h
+++ b/include/GlobalSymbols.h
@@ -25,6 +25,7 @@ typedef struct _GlobalSymbols
     Symbol rb3e_get_album;
     Symbol rb3e_get_origin;
     Symbol rb3e_get_genre;
+    Symbol rb3e_search_song_name;
 
     // modifiers
     Symbol forceHopos;

--- a/source/DTAFunctions.c
+++ b/source/DTAFunctions.c
@@ -26,6 +26,8 @@ typedef struct _song_list_vector {
 } song_list_vector;
 
 static song_list_vector dta_song_list = { 0 };
+extern char *strtok(char *s, const char *delim);
+extern char *strstr(const char *haystack, const char *needle);
 
 DataNode *PrintToDebugger(DataNode *node, DataArray *args)
 {

--- a/source/DTAFunctions.c
+++ b/source/DTAFunctions.c
@@ -370,7 +370,7 @@ DataNode *DTA_SearchSongName(DataNode *node, DataArray *args) {
         ExecuteDTA(PORT_ROCKCENTRALGATEWAY, "{song_select_filter_panel filter_enter}");
         ExecuteDTA(PORT_ROCKCENTRALGATEWAY, "{{music_library get view_settings_provider} select_setting 1}");
         {
-            char buf[64];
+            char buf[80];
             sprintf(buf, "{{music_library get view_settings_provider} select_setting_option %d}", matchedByTitle);
             ExecuteDTA(PORT_ROCKCENTRALGATEWAY, buf);
         }

--- a/source/DTAFunctions.c
+++ b/source/DTAFunctions.c
@@ -17,7 +17,7 @@
 #include "rb3/BandSongMgr.h"
 #include "MusicLibrary.h"
 #include "rb3enhanced.h"
-#include "rb3/RockCentralGateway.h" 
+#include "rb3/RockCentralGateway.h"
 
 typedef struct _song_list_vector {
     int *start;

--- a/source/DTAFunctions.c
+++ b/source/DTAFunctions.c
@@ -322,7 +322,7 @@ DataNode *DTA_SearchSongName(DataNode *node, DataArray *args) {
     int *list;
     int count;
     int i, j;
-    int matchedByTitle, allFound;
+    int matchedByTitle = 0, allFound = 0;
     SongMetadata *md;
     char cleanNeedle[64], cleanTitle[256], cleanArtist[256], tempBuf[64];
     char *tokens[16], *tok;

--- a/source/DTAFunctions.c
+++ b/source/DTAFunctions.c
@@ -17,7 +17,7 @@
 #include "rb3/BandSongMgr.h"
 #include "MusicLibrary.h"
 #include "rb3enhanced.h"
-#include "rb3/RockCentralGateway.h"
+#include "rb3/RockCentralGateway.h" 
 
 typedef struct _song_list_vector {
     int *start;

--- a/source/DTAFunctions.c
+++ b/source/DTAFunctions.c
@@ -377,7 +377,11 @@ DataNode *DTA_SearchSongName(DataNode *node, DataArray *args) {
         ExecuteDTA(PORT_ROCKCENTRALGATEWAY, "{music_library report_sort_and_filters}");
         ExecuteDTA(PORT_ROCKCENTRALGATEWAY, "{song_select_filter_panel filter_exit}");
 
-        MusicLibrarySelectSong(md->shortname.sym);
+        if (matchedByTitle) {
+            MusicLibrarySelectHeading(md->artist.buf);
+        } else {
+            MusicLibrarySelectSong(md->shortname.sym);
+        }
         node->value.string = md->shortname.sym;
         return node;
     }

--- a/source/GlobalSymbols.c
+++ b/source/GlobalSymbols.c
@@ -41,6 +41,7 @@ void InitGlobalSymbols()
     SymbolConstruct(&globalSymbols.rb3e_get_album, "rb3e_get_album");
     SymbolConstruct(&globalSymbols.rb3e_get_origin, "rb3e_get_origin");
     SymbolConstruct(&globalSymbols.rb3e_get_genre, "rb3e_get_genre");
+    SymbolConstruct(&globalSymbols.rb3e_search_song_name, "rb3e_search_song_name");
 
     SymbolConstruct(&globalSymbols.blackBackground, "mod_black_background");
     SymbolConstruct(&globalSymbols.colorShuffle, "mod_color_shuffle");


### PR DESCRIPTION
This adds a new DTAFunction for use by a new commit of rb3dx https://github.com/hmxmilohax/rock-band-3-deluxe/pull/1180

This takes a string input given by the on screen virtual keyboard
String can be for song name, or artist name

The function does as the current rb3e web html song jumping function does
First, dx jumps to the top of the list and resorts to song name
Then each song in the song cache is probed for song name and artist metadata

We prioritize exact matches first, and if no exact matches are found, we search if the string is contained in the metadata
there is no "fuzzy" matching, strictly exact match, or contains.

once we find a match, we resort the song list to either be by song name, or by artist, and jump to the song that was found.

It is MUCH faster than what DX previously did. Let me know thoughts. Thanks.

Here is a preview of the function in action:


https://github.com/user-attachments/assets/1dbcab6c-a8e0-4366-8180-3f9fb0f23703

