### PR TITLE
fix typo in song metadata struct

### DIFF
--- a/include/rb3/SongMetadata.h
+++ b/include/rb3/SongMetadata.h
@@ -24,7 +24,7 @@ typedef struct _SongMetadata
 #ifdef RB3E_WII
     char unknown6[0x10];
 #else
-    char unknown6[0x18];
+    char unknown6[0x14];
 #endif
     Symbol genre;
     int animTempo;


### PR DESCRIPTION
this fixes returning vocal_gender in place of genre for rb3e_get_genre dtafunction