### PR TITLE
Bank 8 enumerate content fail when legacy sd mode is disabled fix

### DIFF
--- a/source/rb3enhanced.c
+++ b/source/rb3enhanced.c
@@ -224,6 +224,10 @@ void ApplyPatches()
     POKE_32(PORT_NASWII_HOST, NOP);
     // always fire the UpdatePresence function. TODO(Emma): look into it, still not firing when screen is changed :/
     POKE_32(PORT_UPDATEPRESENCEBLOCK_B, NOP);
+#ifdef RB3E_WII_BANK8
+    // nop debug crash enumerating content with legacysdmode disabled
+    POKE_32(0x80419158, NOP);
+#endif
 #ifndef RB3E_WII_BANK8
     // always take the branch to 0x8024a628 so vocals can be selected without a mic plugged in
     // bank 8 does not have the mic check


### PR DESCRIPTION
This fixes a specific crash that has popped up in bank8 with the wii cnt stuff if you have legacysdmode disabled

in the words of emma

> the game is calling Debug::Fail and that's what's causing the game to stop - but after the Debug::Fail it's actually cleaning up after itself and failing gracefully without an error
> for this you'd want to just stop that Debug::Fail call from doing anything

it's just a nop specific to this one fail

![image](https://github.com/user-attachments/assets/7bcd3605-d0e7-4ff2-94a6-f4439e7d2162)
