### PR TITLE
allow ini setting to disable metamusic loading

### DIFF
--- a/assets/wii_default_rb3.ini
+++ b/assets/wii_default_rb3.ini
@@ -10,6 +10,8 @@ SongSpeedMultiplier = 1.0
 ForcedVenue = false
 # Whether to unlock all clothing and other unlockables by default.
 UnlockClothing = false
+# Whether to disable all menu background ambient music by default.
+DisableMenuMusic = false
 # The folder to check on the SD card for raw files.
 # The default is "rb3", uncomment this line to change it
 #RawfilesDir = rb3

--- a/assets/xbox_default_rb3.ini
+++ b/assets/xbox_default_rb3.ini
@@ -13,6 +13,8 @@ ForcedVenue = false
 GameOriginIcons = true
 # Whether to unlock all clothing and other unlockables by default.
 UnlockClothing = false
+# Whether to disable all menu background ambient music by default.
+DisableMenuMusic = false
 # The folder to check on the Hard Drive and USB drives for raw files.
 # The default is "rb3", remove the # at the start of this line to change it
 #RawfilesDir = rb3

--- a/include/config.h
+++ b/include/config.h
@@ -23,6 +23,7 @@ typedef struct _RB3E_Config
     char GameOriginIcons;
     char LogFileAccess;
     char UnlockClothing;
+    char DisableMenuMusic;
     char LanguageOverride[RB3E_LANG_LEN + 1];
     char RawfilesDir[RB3E_MAX_CONFIG_LEN];
     char DisableRawfiles;

--- a/include/ports_wii.h
+++ b/include/ports_wii.h
@@ -87,6 +87,10 @@
 #define PORT_SYMBOLPREINIT 0x80364c74            // Symbol::PreInit
 #define PORT_QUEUINGSOCKET_BIND 0x800478d4       // Quazal::QueuingSocket::Bind
 #define PORT_QUAZALSOCKET_BIND 0x8001cd10        // Quazal::Socket::Bind
+#define PORT_METAMUSICISLOADED 0x80678cec        // MetaMusic::Loaded
+#define PORT_METAMUSICLOAD 0x80678990            // MetaMusic::Load
+#define PORT_METAMUSICPOLL 0x80678d20            // MetaMusic::Poll
+#define PORT_METAMUSICSTART 0x80678fa4           // MetaMusic::Start
 #define PORT_INITSONGMETADATA 0x805147a4         // InitSongMetadata
 #define PORT_UPDATEPRESENCE 0x801879d4           // PresenceMgr::UpdatePresence
 #define PORT_STEPSEQUENCEJOBSETSTEP 0x80025364   // Quazal::StepSequenceJob::SetStep

--- a/include/ports_wii_bank8.h
+++ b/include/ports_wii_bank8.h
@@ -89,6 +89,10 @@
 #define PORT_SYMBOLPREINIT 0x804be150          // Symbol::PreInit
 #define PORT_QUEUINGSOCKET_BIND 0x80068820     // Quazal::QueuingSocket::Bind
 #define PORT_QUAZALSOCKET_BIND 0x80029dc0      // Quazal::Socket::Bind
+#define PORT_METAMUSICISLOADED 0x809975d0      // MetaMusic::Loaded
+#define PORT_METAMUSICLOAD 0x809970d0          // MetaMusic::Load
+#define PORT_METAMUSICPOLL 0x80997610          // MetaMusic::Poll
+#define PORT_METAMUSICSTART 0x80997990         // MetaMusic::Start
 #define PORT_INITSONGMETADATA 0x8075a0c0       // InitSongMetadata
 #define PORT_UPDATEPRESENCE 0x8021c3d0         // PresenceMgr::UpdatePresence
 #define PORT_STEPSEQUENCEJOBSETSTEP 0x80035cf0 // Quazal::StepSequenceJob::SetStep

--- a/include/ports_xbox360.h
+++ b/include/ports_xbox360.h
@@ -132,6 +132,10 @@
 #define PORT_MEMPRINTOVERVIEW 0x827bc838             // MemPrintOverview
 #define PORT_MEMPRINT 0x827bc970                     // MemPrint
 #define PORT_MEMNUMHEAPS 0x827bb628                  // MemNumHeaps
+#define PORT_METAMUSICISLOADED 0x8270fab8            // MetaMusic::Loaded
+#define PORT_METAMUSICLOAD 0x82710ab0                // MetaMusic::Load
+#define PORT_METAMUSICPOLL 0x82711438                // MetaMusic::Poll
+#define PORT_METAMUSICSTART 0x82711a00               // MetaMusic::Start
 #define PORT_INITSONGMETADATA 0x827aa450             // InitSongMetadata
 #define PORT_UPDATEPRESENCE 0x82680430               // PresenceMgr::UpdatePresence
 #define PORT_STEPSEQUENCEJOBSETSTEP 0x82af92b8       // Quazal::StepSequenceJob::SetStep

--- a/source/config.c
+++ b/source/config.c
@@ -59,6 +59,8 @@ static int INIHandler(void *user, const char *section, const char *name, const c
             config.LogFileAccess = RB3E_CONFIG_BOOL(value);
         if (strcmp(name, "UnlockClothing") == 0)
             config.UnlockClothing = RB3E_CONFIG_BOOL(value);
+        if (strcmp(name, "DisableMenuMusic") == 0)
+            config.DisableMenuMusic = RB3E_CONFIG_BOOL(value);
         if (strcmp(name, "LanguageOverride") == 0 && strlen(value) == RB3E_LANG_LEN)
             strncpy(config.LanguageOverride, value, RB3E_LANG_LEN);
         if (strcmp(name, "RawfilesDir") == 0 && !RB3E_CONFIG_FALSE(value))

--- a/source/rb3enhanced.c
+++ b/source/rb3enhanced.c
@@ -279,6 +279,17 @@ void ApplyConfigurablePatches()
         POKE_32(PORT_VIDEO_VENUE_CHECK, LI(3, 1));
     }
 
+    if (config.DisableMenuMusic == 1)
+    {
+        // Disables MetaMusic from loading, saves space on the heap
+        POKE_32(PORT_METAMUSICLOAD, BLR);
+        POKE_32(PORT_METAMUSICSTART, BLR);
+        POKE_32(PORT_METAMUSICPOLL, BLR);
+        // Always return 1 from MetaMusic::Loaded, in MetaPanel::IsLoaded
+        POKE_32(PORT_METAMUSICISLOADED, LI(3, 1));
+        POKE_32(PORT_METAMUSICISLOADED + 4, BLR);
+    }
+
 #ifdef RB3EDEBUG
     if (config.QuazalLogging == 1)
     {


### PR DESCRIPTION
this is honestly just a cool feature tbh, because of the ambient noises in all of the menus, but, this adds an ini setting to... yeah the title.

This doesn't just mute it either, proper killed loading of the metaloop into memory entirely, which will save anywhere from 1-2mb of ram at any given time in the HD versions, which is helpful for rb3dx long sessions.

Tested:
Wii Bank8
Xbox Hardware
Xenia

Not Tested:
Wii retail (function addresses were labeled thanks to the decomp)