### PR TITLE
hotfix song metadata struct to fix genre return

### DIFF
--- a/include/rb3/SongMetadata.h
+++ b/include/rb3/SongMetadata.h
@@ -24,7 +24,7 @@ typedef struct _SongMetadata
 #ifdef RB3E_WII
     char unknown6[0x10];
 #else
-    char unknown6[0x14];
+    char unknown6[0x10]; // hotfixed from 0x18, then 0x14? what is happening
 #endif
     Symbol genre;
     int animTempo;


### PR DESCRIPTION
gonna level with you, I don't know.
but it is crashing otherwise as is, and I verified twice over that 0x10 works to fix the get genre dta func