### PR TITLE
[xbox] add keyboard support back into xbox retail

### DIFF
--- a/include/ports_xbox360.h
+++ b/include/ports_xbox360.h
@@ -149,6 +149,7 @@
 #define PORT_DATASETELEM 0x82760b38                  // DataSetElem
 #define PORT_DATAONELEM 0x8275ff50                   // DataOnElem
 #define PORT_DATANODEGETOBJ 0x8274b088               // DataNode::GetObj
+#define PORT_DATAARRAYEXECUTE 0x8274d198             // DataArray::Execute
 #define PORT_DXRND_SUSPEND 0x8273A370                // DxRnd::Suspend
 #define PORT_XBOXCONTENT_CONSTRUCTOR 0x8251fb40      // XboxContent::__ct
 #define PORT_CACHEMGRXBOX_MOUNTASYNC 0x827d7b38      // CacheMgrXbox::MountAsync

--- a/include/rb3/Data.h
+++ b/include/rb3/Data.h
@@ -82,6 +82,8 @@ extern DataNode *DataSet(DataNode *ret, DataArray *array);
 extern DataNode *DataSetElem(DataNode *ret, DataArray *array);
 extern DataNode *DataOnElem(DataNode *ret, DataArray *array);
 
+extern DataNode *DataArrayExecute(DataNode *ret, DataArray *thisArr);
+
 extern void *DataNodeGetObj(DataNode *node);
 
 // inlined on 360

--- a/source/_functions.c
+++ b/source/_functions.c
@@ -112,6 +112,7 @@ RB3E_STUB(HeapInit)
 RB3E_STUB(ResolvedModuleKeyboard)
 RB3E_STUB(XboxContentConstruct)
 RB3E_STUB(CacheMgrXbox_MountAsync)
+RB3E_STUB(DataArrayExecute)
 
 #ifdef RB3E_WII
 // Wii-specific functions

--- a/source/rb3enhanced.c
+++ b/source/rb3enhanced.c
@@ -171,6 +171,7 @@ static unsigned int framecount = 0;
 // STUFF YOU DO HERE WILL **DIRECTLY** IMPACT THE GAME'S FRAMERATE!
 void HTTP_Server_RunLoop();
 void Liveless_Poll();
+void KeyboardPoll();
 void RB3E_RunLoop()
 {
     if (config.EnableNATPMP)
@@ -182,6 +183,7 @@ void RB3E_RunLoop()
         Liveless_Poll();
     if (config.EnableUPnP)
         UPNP_Poll();
+    KeyboardPoll();
 #endif
 #ifdef RB3EDEBUG
     // print out memory every 5 seconds
@@ -385,6 +387,9 @@ void InitialiseFunctions()
     POKE_B(&BinstreamRead, PORT_BINSTREAMREAD);
     POKE_B(&BinstreamWriteEndian, PORT_BINSTREAMWRITEENDIAN);
     POKE_B(&BinstreamReadEndian, PORT_BINSTREAMREADENDIAN);
+#ifdef RB3E_XBOX
+    POKE_B(&DataArrayExecute, PORT_DATAARRAYEXECUTE);
+#endif
 #ifndef RB3E_XBOX
     POKE_B(&DataRegisterFunc, PORT_DATAREGISTERFUNC);
 #endif

--- a/source/xbox_keyboard.c
+++ b/source/xbox_keyboard.c
@@ -1,0 +1,148 @@
+#ifdef RB3E_XBOX
+#include <xtl.h>
+#include "rb3/Data.h"
+#include "ports.h"
+
+// Copy-pasted from DC3 ghidra decompile output
+// This function translates the system XInput VirtualKey value into Harmonix's keycode values
+int TranslateVK(unsigned short virtualKey, char shift)
+{
+  unsigned int _C;
+  unsigned int uVar1;
+  
+  _C = (unsigned int)virtualKey;
+  if ((((0x2f < _C) && (_C < 0x3a)) || ((uVar1 = 0, 0x40 < _C && (_C < 0x5b)))) &&
+     (uVar1 = _C, !shift)) {
+    uVar1 = tolower(_C);
+  }
+  if ((0x6f < _C) && (_C < 0x7c)) {
+    uVar1 = _C + 0x121;
+  }
+  if (virtualKey < 0x25) {
+    if (_C == 0x24) {
+      uVar1 = 0x138;
+    }
+    else if (virtualKey < 0x15) {
+      if (_C == 0x14) {
+        uVar1 = 0x122;
+      }
+      else if (_C == 8) {
+        uVar1 = 8;
+      }
+      else if (_C == 9) {
+        uVar1 = 9;
+      }
+      else if (_C == 0xd) {
+        uVar1 = 10;
+      }
+      else if (_C == 0x13) {
+        uVar1 = 0x12d;
+      }
+    }
+    else if (_C == 0x1b) {
+      uVar1 = 0x12e;
+    }
+    else if (_C == 0x21) {
+      uVar1 = 0x13a;
+    }
+    else if (_C == 0x22) {
+      uVar1 = 0x13b;
+    }
+    else if (_C == 0x23) {
+      uVar1 = 0x139;
+    }
+  }
+  else if (virtualKey < 0x2b) {
+    if (_C == 0x2a) {
+      uVar1 = 300;
+    }
+    else if (_C == 0x25) {
+      uVar1 = 0x140;
+    }
+    else if (_C == 0x26) {
+      uVar1 = 0x142;
+    }
+    else if (_C == 0x27) {
+      uVar1 = 0x141;
+    }
+    else if (_C == 0x28) {
+      uVar1 = 0x143;
+    }
+  }
+  else if (_C == 0x2d) {
+    uVar1 = 0x136;
+  }
+  else if (_C == 0x2e) {
+    uVar1 = 0x137;
+  }
+  else if (_C == 0x90) {
+    uVar1 = 0x123;
+  }
+  else if (_C == 0x91) {
+    uVar1 = 0x124;
+  }
+  return uVar1;
+}
+
+
+// Reimplementation of KeyboardPoll from DC3
+void KeyboardPoll() {
+    XINPUT_KEYSTROKE keystroke;
+    DWORD keystrokeResult;
+    static DataNode msgNodes[6] = {0};
+    static DataArray keyMsg = {0};
+    static DataNode retNode;
+    Symbol uiSym;
+    Symbol keySym;
+    char unicodeChar[4];
+    int keyCode;
+    
+    keystrokeResult = XInputGetKeystroke(XUSER_INDEX_ANY, 2, &keystroke);
+    if (keystrokeResult == ERROR_SUCCESS && (keystroke.Flags & XINPUT_KEYSTROKE_KEYUP) == 0) {
+        WideCharToMultiByte(0, 0, &keystroke.Unicode, 1, unicodeChar, 2, 0x0, 0x0);
+        if (unicodeChar[0] == '\0' || unicodeChar[0] < ' ' || unicodeChar[0] > '~') {
+            keyCode = TranslateVK(keystroke.VirtualKey, (keystroke.Flags & XINPUT_KEYSTROKE_SHIFT) > 0);
+        } else {
+            keyCode = (int)unicodeChar[0];
+        }
+
+        keyMsg.mNodes = (DataNodes *)&msgNodes;
+        keyMsg.mNodeCount = 6;
+        keyMsg.mRefCount = 1;
+        keyMsg.mFile = *(Symbol *)PORT_NULLSYMBOL;
+
+        SymbolConstruct(&uiSym, "ui");
+        SymbolConstruct(&keySym, "key");
+
+        // Construct a command array to do this:
+        // {ui key $key $shift $ctrl $alt}
+
+        // ui object
+        msgNodes[0].type = SYMBOL;
+        msgNodes[0].value.string = uiSym.sym;
+
+        // key handler
+        msgNodes[1].type = SYMBOL;
+        msgNodes[1].value.string = keySym.sym;
+
+        // key
+        msgNodes[2].type = INT_VALUE;
+        msgNodes[2].value.intVal = keyCode;
+
+        // shift
+        msgNodes[3].type = INT_VALUE;
+        msgNodes[3].value.intVal = (keystroke.Flags & XINPUT_KEYSTROKE_SHIFT) > 0;
+
+        // ctrl
+        msgNodes[4].type = INT_VALUE;
+        msgNodes[4].value.intVal = (keystroke.Flags & XINPUT_KEYSTROKE_CTRL) > 0;
+
+        // alt
+        msgNodes[5].type = INT_VALUE;
+        msgNodes[5].value.intVal = (keystroke.Flags & XINPUT_KEYSTROKE_ALT) > 0;
+        
+        DataArrayExecute(&retNode, &keyMsg);
+
+    }
+}
+#endif

--- a/source/xbox_keyboard.c
+++ b/source/xbox_keyboard.c
@@ -3,85 +3,68 @@
 #include "rb3/Data.h"
 #include "ports.h"
 
-// Copy-pasted from DC3 ghidra decompile output
+// Reimplementation of DC3's TranslateVK
 // This function translates the system XInput VirtualKey value into Harmonix's keycode values
-int TranslateVK(unsigned short virtualKey, char shift)
+int TranslateVK(DWORD virtualKey, char shift)
 {
-  unsigned int _C;
-  unsigned int uVar1;
-  
-  _C = (unsigned int)virtualKey;
-  if ((((0x2f < _C) && (_C < 0x3a)) || ((uVar1 = 0, 0x40 < _C && (_C < 0x5b)))) &&
-     (uVar1 = _C, !shift)) {
-    uVar1 = tolower(_C);
-  }
-  if ((0x6f < _C) && (_C < 0x7c)) {
-    uVar1 = _C + 0x121;
-  }
-  if (virtualKey < 0x25) {
-    if (_C == 0x24) {
-      uVar1 = 0x138;
+    // ASCII range
+    // Honestly not sure why this range is even mapped, at these ranges the Unicode translation should be handling it
+    if (virtualKey >= 0x41 && virtualKey <= 0x5a) {
+        if (!shift) {
+            return virtualKey;
+        } else {
+            return tolower(virtualKey);
+        }
     }
-    else if (virtualKey < 0x15) {
-      if (_C == 0x14) {
-        uVar1 = 0x122;
-      }
-      else if (_C == 8) {
-        uVar1 = 8;
-      }
-      else if (_C == 9) {
-        uVar1 = 9;
-      }
-      else if (_C == 0xd) {
-        uVar1 = 10;
-      }
-      else if (_C == 0x13) {
-        uVar1 = 0x12d;
-      }
+
+    // Function key range
+    if (virtualKey >= VK_F1 && virtualKey <= VK_F12) {
+        return virtualKey + 0x121;
     }
-    else if (_C == 0x1b) {
-      uVar1 = 0x12e;
+
+    // Other keycode mappings
+    switch (virtualKey) {
+    case VK_HOME:
+        return 0x138;
+    case VK_CAPITAL:
+        return 0x122;
+    case VK_BACK:
+        return 0x08;
+    case VK_TAB:
+        return 0x09;
+    case VK_RETURN:
+        return 0x0a;
+    case VK_PAUSE:
+        return 0x12d;
+    case VK_ESCAPE:
+        return 0x12e;
+    case VK_PRIOR:
+        return 0x13a;
+    case VK_NEXT:
+        return 0x13b;
+    case VK_END:
+        return 0x139;
+    case VK_PRINT:
+        return 0x12c;
+    case VK_LEFT:
+        return 0x140;
+    case VK_UP:
+        return 0x142;
+    case VK_RIGHT:
+        return 0x141;
+    case VK_DOWN:
+        return 0x143;
+    case VK_INSERT:
+        return 0x136;
+    case VK_DELETE:
+        return 0x137;
+    case VK_NUMLOCK:
+        return 0x123;
+    case VK_SCROLL:
+        return 0x124;
     }
-    else if (_C == 0x21) {
-      uVar1 = 0x13a;
-    }
-    else if (_C == 0x22) {
-      uVar1 = 0x13b;
-    }
-    else if (_C == 0x23) {
-      uVar1 = 0x139;
-    }
-  }
-  else if (virtualKey < 0x2b) {
-    if (_C == 0x2a) {
-      uVar1 = 300;
-    }
-    else if (_C == 0x25) {
-      uVar1 = 0x140;
-    }
-    else if (_C == 0x26) {
-      uVar1 = 0x142;
-    }
-    else if (_C == 0x27) {
-      uVar1 = 0x141;
-    }
-    else if (_C == 0x28) {
-      uVar1 = 0x143;
-    }
-  }
-  else if (_C == 0x2d) {
-    uVar1 = 0x136;
-  }
-  else if (_C == 0x2e) {
-    uVar1 = 0x137;
-  }
-  else if (_C == 0x90) {
-    uVar1 = 0x123;
-  }
-  else if (_C == 0x91) {
-    uVar1 = 0x124;
-  }
-  return uVar1;
+
+    return virtualKey;
 }
 
 


### PR DESCRIPTION
Allows Xbox to fire the keyboard handler, so the new RB3DX search can be used without opening the virtual keyboard. 